### PR TITLE
Mission Accomplishment Callback

### DIFF
--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -20,7 +20,7 @@ class MissionsController < ApplicationController
     unless @enrolled_missions.detect{|x| x.mission_id == @mission.id}
       redirect_to(root_path) and return
     end
-    @next_mission = @user.mission_enrollments.unaccomplished.first.try(:mission)
+    @next_mission = @mission.next_mission
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -65,4 +65,8 @@ module ApplicationHelper
     content_tag(:iframe,"",src: FormattedURL.url(url, :embed), frameborder: '0', allowfullscreen: 'allowfullscreen', width: 640,height: 360)
   end
 
+  def validation_params(resource)
+    ValidationParams.new(resource.validation_params).to_hash
+  end
+
 end

--- a/app/mailers/mission_mailer.rb
+++ b/app/mailers/mission_mailer.rb
@@ -1,0 +1,6 @@
+class MissionMailer < ActionMailer::Base
+  def accomplished_mission(mission_enrollment, user)
+    @mission = mission_enrollment.mission
+    mail(:to => user.email, :subject => I18n.t('mails.accomplished_mission.subject'))
+  end
+end

--- a/app/models/mission_enrollment.rb
+++ b/app/models/mission_enrollment.rb
@@ -64,14 +64,10 @@ class MissionEnrollment < ActiveRecord::Base
     mission_id
   end
 
-  # Returns composed validation params
-  def validation_params
-    @validation_params ||= ValidationParams.new(self[:validation_params].to_s)
-  end
-
   protected
+
   def accomplished_callback
-    'Not done yet, need to create badges'
+    MissionMailer.accomplished_mission(self, self.user).deliver
   end
 
   def fill_url

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,8 +73,25 @@ class User < ActiveRecord::Base
     mission_enrollments.find_by_mission_id(current_mission.try(:id))
   end
 
+  # If current user is OK with all mission enrollments
+  def accomplished_all_enrolled_missions?
+    mission_enrollments.select{|m| !m.accomplished? }.empty?
+  end
+
+  # Returns the last +MissionEnrollment+
+  def last_accomplished_mission_enrollment
+    mission_enrollments.accomplished.last
+  end
+
+  def current_or_last_accomplished_mission_enrollment
+    return last_accomplished_mission_enrollment if accomplished_all_enrolled_missions?
+    current_mission_enrollment
+  end
+
+  # If user can enroll the next mission
   def can_enroll?(mission)
     (mission_enrollments.empty? && (mission == Mission.first_mission)) ||
-    (current_mission_enrollment && current_mission_enrollment.accomplished?)
+    ( (current_or_last_accomplished_mission_enrollment && current_or_last_accomplished_mission_enrollment.accomplished?) &&
+    (last_accomplished_mission_enrollment.mission.next_mission == mission ) )
   end
 end

--- a/app/presenters/facebook_social_mission_validator_presenter.rb
+++ b/app/presenters/facebook_social_mission_validator_presenter.rb
@@ -38,10 +38,9 @@ class FacebookSocialMissionValidatorPresenter < MissionPresenter
 
   protected
   def im_ready_button
-    #mission_enrollment = view.current_user.mission_enrollments.find_by_mission_id(mission.id)
-    #unless mission_enrollment.present?
-    #  view.link_to(I18n.t('mission.presenter.im_ready'), view.new_mission_mission_enrollment_path(mission), class: 'btn')
-    #end
-    # TODO: show the im_ready button
+    mission_enrollment = view.current_user.mission_enrollments.find_by_mission_id(mission.id)
+    unless mission_enrollment.present?
+      view.link_to(I18n.t('mission.presenter.im_ready'), view.new_mission_mission_enrollment_path(mission), class: 'btn')
+    end
   end
 end

--- a/app/views/mission_enrollments/_enrolled_missions.html.erb
+++ b/app/views/mission_enrollments/_enrolled_missions.html.erb
@@ -6,7 +6,7 @@
         <% if enrolled_mission.mission.badge.present? %>
           <li><%= image_tag(enrolled_mission.mission.badge.image.small) %></li>
         <% end %>
-        <li><h2><%= t("mission.like_count", quantity: enrolled_mission.validation_params.to_hash[:likes]) %></h2></li>
+        <li><h2><%= t("mission.like_count", quantity: validation_params(enrolled_mission)[:likes]) %></h2></li>
         <li><%= image_tag("icons/check.jpg") %></li>
       </ul>
     </li>

--- a/app/views/mission_mailer/accomplished_mission.html.erb
+++ b/app/views/mission_mailer/accomplished_mission.html.erb
@@ -1,0 +1,24 @@
+<h2>Greetings Star Hero!</h2>
+
+<p>
+We are happy to announce you just completed your mission, and can now move to the next one.
+</p>
+
+<p>
+Before you rush off too fast to the next mission, just remember that the more you share what 
+you have already accomplished with your friends and community, the more that people will know what you are doing, and they’ll be eager to help you!
+</p>
+
+<p>
+Click on the link below to receive your next mission:
+</p>
+
+<%= link_to(@mission.title,congratulations_mission_url(@mission)) %>
+<p>
+Keep up the good work!
+</p>
+
+<p>
+Your Friends, <br />
+The People of the Stars
+</p>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -4,4 +4,6 @@ require File.expand_path('../application', __FILE__)
 # Initialize the rails application
 PlayTheCall::Application.initialize!
 
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+unless Rails.env.test?
+  ActiveRecord::Base.logger = Logger.new(STDOUT)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,8 @@ en:
       body:   "Go to the link below to recover your password."
       link:   "Recover your password"
       footer: "If you haven't send this e-mail, please ignore this message."
+    accomplished_mission:
+      subject: "Mission Completed!"
   mission:
     oracle_field: "Please tell us who is your Oracle"
     pluralized: "Missions"

--- a/spec/mailers/mission_mailer_spec.rb
+++ b/spec/mailers/mission_mailer_spec.rb
@@ -1,0 +1,14 @@
+require "spec_helper"
+
+describe MissionMailer do
+  let(:mission) { mock_model(Mission, :id => -1) }
+  let(:mission_enrollment) { mock_model(MissionEnrollment, :mission => mission) }
+  let(:user) { mock_model(User, :email => 'test@email.com') }
+
+  describe "#accomplished_mission" do
+    subject { MissionMailer.accomplished_mission(mission_enrollment, user) }
+    it 'should send accomplished e-mail' do
+      expect { subject.deliver }.to change(ActionMailer::Base.deliveries, :size)
+    end
+  end
+end

--- a/spec/models/mission_enrollment_spec.rb
+++ b/spec/models/mission_enrollment_spec.rb
@@ -26,14 +26,6 @@ describe MissionEnrollment do
     end
   end
 
-  describe "#validation_params" do
-    subject { MissionEnrollment.new }
-
-    it 'should return a composed object of ValidationParams' do
-      subject.validation_params.class.should == ValidationParams
-    end
-  end
-
   #context '#notify_oracle' do
   #  clean_with_transaction_on :each
 


### PR DESCRIPTION
Send e-mail to the user that complete the mission
- Enable the "I'm ready button" again (@bezelga and @philss)
- Sends the complete mission e-mail
- Fix the "Next mission" link on congratulations page
- Improves the User#can_enroll? method(@bezelga and @philss)

This commit is related to #137
